### PR TITLE
#1 スニペット削除機能 の実装

### DIFF
--- a/snippets/templates/snippets/snippet_detail.html
+++ b/snippets/templates/snippets/snippet_detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load pygmentize %}
+{% load django_bootstrap5 %}
 
 {% block extraheader %}
 <style>{% pygments_css %}</style>
@@ -12,6 +13,11 @@
     投稿日: {{ snippet.created_at|date:"DATETIME_FORMAT" }}
     {% if user.is_authenticated and snippet.created_by_id == user.id %}
     <a href="{% url 'snippet_edit' snippet.id %}">編集</a>
+    <a href="{% url 'snippet_delete' snippet.id %}">削除</a>
+    <!-- <form method="post">
+        {% csrf_token %}
+        {% bootstrap_button button_type="submit" content="削除" %}
+    </form> -->
     {% endif %}
 </div>
 

--- a/snippets/templates/snippets/snippet_detail.html
+++ b/snippets/templates/snippets/snippet_detail.html
@@ -14,10 +14,6 @@
     {% if user.is_authenticated and snippet.created_by_id == user.id %}
     <a href="{% url 'snippet_edit' snippet.id %}">編集</a>
     <a href="{% url 'snippet_delete' snippet.id %}">削除</a>
-    <!-- <form method="post">
-        {% csrf_token %}
-        {% bootstrap_button button_type="submit" content="削除" %}
-    </form> -->
     {% endif %}
 </div>
 

--- a/snippets/templates/snippets/snippet_detail.html
+++ b/snippets/templates/snippets/snippet_detail.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load pygmentize %}
-{% load django_bootstrap5 %}
 
 {% block extraheader %}
 <style>{% pygments_css %}</style>

--- a/snippets/urls.py
+++ b/snippets/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path("new/", views.snippet_new, name="snippet_new"),
     path("<int:snippet_id>/", views.snippet_detail, name="snippet_detail"),
     path("<int:snippet_id>/edit/", views.snippet_edit, name="snippet_edit"),
+    path("<int:snippet_id>/delete/", views.snippet_delete, name="snippet_delete"),
 ]

--- a/snippets/views.py
+++ b/snippets/views.py
@@ -28,11 +28,13 @@ def snippet_new(request):
 
 @login_required
 def snippet_edit(request, snippet_id):
+    print("snippet_idsnippet_idsnippet_id:", snippet_id)
     snippet = get_object_or_404(Snippet, pk=snippet_id)
     if snippet.created_by_id != request.user.id:
         return HttpResponseForbidden("このスニペットの編集は許可されていません。")
 
     if request.method == "POST":
+        print("本当に飛んでんのか？お？")
         form = SnippetForm(request.POST, instance=snippet)
         if form.is_valid():
             form.save()
@@ -40,6 +42,24 @@ def snippet_edit(request, snippet_id):
     else:
         form = SnippetForm(instance=snippet)
     return render(request, 'snippets/snippet_edit.html', {'form': form})
+
+@login_required
+def snippet_delete(request, snippet_id):
+    print("snippet_delete")
+    print("snippet_id:", snippet_id)
+    snippet = get_object_or_404(Snippet, pk=snippet_id)
+    if snippet.created_by_id != request.user.id:
+        return HttpResponseForbidden("このスニペットの削除は許可されていません。")
+
+    return redirect('snippet_detail', snippet_id=snippet_id)
+    # if request.method == "POST":
+    #     form = SnippetForm(request.POST, instance=snippet)
+    #     if form.is_valid():
+    #         form.save()
+    #         return redirect('snippet_detail', snippet_id=snippet_id)
+    # else:
+    #     form = SnippetForm(instance=snippet)
+    # return render(request, 'snippets/snippet_edit.html', {'form': form})
 
 
 def snippet_detail(request, snippet_id):

--- a/snippets/views.py
+++ b/snippets/views.py
@@ -28,13 +28,11 @@ def snippet_new(request):
 
 @login_required
 def snippet_edit(request, snippet_id):
-    print("snippet_idsnippet_idsnippet_id:", snippet_id)
     snippet = get_object_or_404(Snippet, pk=snippet_id)
     if snippet.created_by_id != request.user.id:
         return HttpResponseForbidden("このスニペットの編集は許可されていません。")
 
     if request.method == "POST":
-        print("本当に飛んでんのか？お？")
         form = SnippetForm(request.POST, instance=snippet)
         if form.is_valid():
             form.save()
@@ -45,8 +43,6 @@ def snippet_edit(request, snippet_id):
 
 @login_required
 def snippet_delete(request, snippet_id):
-    print("snippet_delete")
-    print("snippet_id:", snippet_id)
     snippet = get_object_or_404(Snippet, pk=snippet_id)
     if snippet.created_by_id != request.user.id:
         return HttpResponseForbidden("このスニペットの削除は許可されていません。")

--- a/snippets/views.py
+++ b/snippets/views.py
@@ -50,16 +50,9 @@ def snippet_delete(request, snippet_id):
     snippet = get_object_or_404(Snippet, pk=snippet_id)
     if snippet.created_by_id != request.user.id:
         return HttpResponseForbidden("このスニペットの削除は許可されていません。")
-
+    
+    snippet.delete()
     return redirect('top')
-    # if request.method == "POST":
-    #     form = SnippetForm(request.POST, instance=snippet)
-    #     if form.is_valid():
-    #         form.save()
-    #         return redirect('snippet_detail', snippet_id=snippet_id)
-    # else:
-    #     form = SnippetForm(instance=snippet)
-    # return render(request, 'snippets/snippet_edit.html', {'form': form})
 
 
 def snippet_detail(request, snippet_id):

--- a/snippets/views.py
+++ b/snippets/views.py
@@ -51,7 +51,7 @@ def snippet_delete(request, snippet_id):
     if snippet.created_by_id != request.user.id:
         return HttpResponseForbidden("このスニペットの削除は許可されていません。")
 
-    return redirect('snippet_detail', snippet_id=snippet_id)
+    return redirect('top')
     # if request.method == "POST":
     #     form = SnippetForm(request.POST, instance=snippet)
     #     if form.is_valid():


### PR DESCRIPTION
## 内容
- API snippet_delete を新しく追加し、基本的には編集と同じHTML要素よりクリックすると削除が走るように実装しました。

## issue
https://github.com/bob-g12/post_snippets/issues/1

## 動作確認
- とりあえず、削除ボタンを押した際にデータが削除されていることと、画面がtopページに遷移されることを確認
https://github.com/bob-g12/post_snippets/assets/62760395/d3c1c5c5-ed82-4117-b69c-7ff6d40836f4

## 要注意点
- とりあえず動くところまでやったため、HTTPメソッドがPOSTではなくGETになっています![maybe_banana](https://github.com/bob-g12/post_snippets/assets/62760395/431e3341-4652-4a59-b7a1-48cea6c659d1)
- また、POSTメソッドで送っているかどうかの判定もついていないため、要変更が必要なコードです。

